### PR TITLE
fix(driver): accept plain numeric version strings from Firebird Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`src/Driver/FirebirdDriver.php`** — Accept plain numeric version strings (e.g. `"5.0.3.1683"`)
+  returned by newer `firebirdsql/firebird` Docker images in addition to the legacy
+  `"LI|WI-V<major>.<minor>.<patch>.<build>"` format. Fixes all CI matrix jobs failing with
+  `Invalid platform version` exceptions (#82)
+
 ## [3.10.0] - 2026-03-04
 
 ### Added

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,18 +1,78 @@
 # Next Steps — doctrine-firebird-driver
 
-**Last session:** 2026-03-04 (issue #82 fixed — CI matrix version parsing, PR #83 open, all 6 matrix jobs green)
+**Last session:** 2026-03-05 (PR #83 rebased on updated 3.0.x, CI re-triggered)
 **Branch:** `fix/ci-matrix-version-parsing` → PR #83 → `3.0.x` | **Tag:** `v3.10.0` ✅
 
-## 🔴 Immediate — Merge PR #83 then PR #81
+---
+
+## 🔴 Priority 1 — Merge PR #83 → then PR #81
+
+### Step 1: Merge PR #83 (fixes issue #82)
 
 | PR | Title | Status |
 |----|-------|--------|
-| #83 | fix(driver): accept plain numeric version strings from Firebird Docker images | ✅ CI green — **needs review + merge** |
-| #81 | feat: php-firebird v7.2.0 compatibility | ⏳ Blocked by #83 — unblocks after #83 merges |
+| **#83** | fix(driver): accept plain numeric version strings from Firebird Docker images | ✅ CI green (rebased 2026-03-05) — **needs review + merge** |
 
-**After merging #83**: Re-run CI on PR #81 to confirm it passes on the fixed base branch.
+```bash
+# Merge PR #83 (squash recommended)
+gh pr merge 83 --repo satwareAG/doctrine-firebird-driver --squash --delete-branch
+```
 
-**AppVeyor note**: AppVeyor checks fail on both PRs — this is a pre-existing legacy CI infrastructure issue on `3.0.x` unrelated to our changes. AppVeyor is not a required check for merge.
+**AppVeyor note**: AppVeyor checks fail — pre-existing legacy CI infrastructure issue on `3.0.x`, not a required check for merge.
+
+### Step 2: Re-run CI on PR #81 after #83 merges
+
+| PR | Title | Status |
+|----|-------|--------|
+| **#81** | feat(deps): php-firebird v7.2.0 compatibility | ⏳ Blocked by #83 — unblocks after #83 merges |
+
+```bash
+# After #83 merges, rebase #81 on updated 3.0.x
+cd /tmp/doctrine-firebird-driver
+git checkout feat/php-firebird-7.2.0-compat
+git rebase origin/3.0.x
+git push --force-with-lease origin feat/php-firebird-7.2.0-compat
+# Then verify CI passes on PR #81
+gh run list --repo satwareAG/doctrine-firebird-driver --branch feat/php-firebird-7.2.0-compat --limit 3
+```
+
+---
+
+## 🟡 Priority 2 — GitLab MRs (php-firebird v7.2.0 compat)
+
+Both GitLab MRs are open and waiting for doctrine-firebird-driver PRs to merge first:
+
+| Repo | MR | Title | Status |
+|------|----|-------|--------|
+| `satware/satag-amicron-entity-bundle` | !25 | feat(deps): php-firebird v7.2.0 compatibility | ⏳ Waiting for doctrine-firebird-driver |
+| `satware/amicron-platform` | !116 | feat(deps): php-firebird v7.2.0 compatibility | ⏳ Waiting for entity bundle |
+
+**Dependency chain**: PR #83 → PR #81 → MR !25 → MR !116
+
+### Open GitLab Issues (from v7.2.0 release session)
+
+| Repo | Issue | Title |
+|------|-------|-------|
+| amicron-platform | #75 | chore(ci): replace composer -q with proper error handling |
+| amicron-platform | #76 | chore(deps): upgrade satag/doctrine-firebird-driver to ^3.10 when entity bundle allows it |
+| amicron-platform | #77 | chore(ci): document CI image upgrade from PHP 8.1 to 8.2 |
+| satag-amicron-entity-bundle | #51 | chore(deps): relax satag/doctrine-firebird-driver constraint to allow ^3.10 |
+
+---
+
+## 🟢 Priority 3 — Release v3.10.1 patch
+
+After PR #83 merges, tag a patch release:
+
+```bash
+git checkout 3.0.x && git pull
+git tag -a v3.10.1 -m "fix(driver): accept plain numeric version strings from Firebird Docker images (#82)"
+git push origin v3.10.1
+gh release create v3.10.1 --repo satwareAG/doctrine-firebird-driver \
+  --target 3.0.x \
+  --title "v3.10.1 — Fix CI matrix version parsing" \
+  --notes "Fixes all CI matrix jobs failing with 'Invalid platform version' when using newer firebirdsql/firebird Docker images that return plain numeric version strings (e.g. '5.0.3.1683') instead of the legacy 'LI|WI-V...' format. Closes #82."
+```
 
 ---
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,6 +1,22 @@
 # Next Steps — doctrine-firebird-driver
 
-**Last session:** 2026-03-04 (v3.10.0 stable released — CHANGELOG updated, tag pushed, GitHub release created, issue #58 closed)
+**Last session:** 2026-03-04 (issue #82 fixed — CI matrix version parsing, PR #83 open, all 6 matrix jobs green)
+**Branch:** `fix/ci-matrix-version-parsing` → PR #83 → `3.0.x` | **Tag:** `v3.10.0` ✅
+
+## 🔴 Immediate — Merge PR #83 then PR #81
+
+| PR | Title | Status |
+|----|-------|--------|
+| #83 | fix(driver): accept plain numeric version strings from Firebird Docker images | ✅ CI green — **needs review + merge** |
+| #81 | feat: php-firebird v7.2.0 compatibility | ⏳ Blocked by #83 — unblocks after #83 merges |
+
+**After merging #83**: Re-run CI on PR #81 to confirm it passes on the fixed base branch.
+
+**AppVeyor note**: AppVeyor checks fail on both PRs — this is a pre-existing legacy CI infrastructure issue on `3.0.x` unrelated to our changes. AppVeyor is not a required check for merge.
+
+---
+
+**Previous session:** 2026-03-04 (v3.10.0 stable released — CHANGELOG updated, tag pushed, GitHub release created, issue #58 closed)
 **Branch:** `3.0.x` | **Tag:** `v3.10.0` ✅ | **Commit:** `315b7e0`
 
 ---

--- a/src/Driver/FirebirdDriver.php
+++ b/src/Driver/FirebirdDriver.php
@@ -52,6 +52,9 @@ abstract class FirebirdDriver implements Driver, VersionAwarePlatformDriver // @
     /**
      * Factory method for creating the appropriate platform instance for the given version.
      *
+     * Accepts both the legacy Firebird version string format ("LI|WI-V<major>.<minor>.<patch>.<build>")
+     * and the plain numeric format returned by newer Firebird Docker images ("<major>.<minor>.<patch>.<build>").
+     *
      * @param mixed $version The platform/server version string to evaluate.
      *
      * @throws Exception If the given version string could not be evaluated.
@@ -66,24 +69,39 @@ abstract class FirebirdDriver implements Driver, VersionAwarePlatformDriver // @
         }
 
         $versionParts = [];
+
+        // Accept legacy format: "LI-V3.0.13.33818", "WI-V4.0.5.3116", "LI-T3.0.0.29316"
         if (
             preg_match(
                 '/^(LI|WI)-([VT])(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+)(?:\.(?P<build>\d+))?)?)?/',
                 $version,
                 $versionParts,
-            ) !== 1
+            ) === 1
         ) {
+            $majorVersion = $versionParts['major'];
+            $minorVersion = $versionParts['minor'] ?? 0;
+            $patchVersion = $versionParts['patch'] ?? 0;
+            $buildVersion = $versionParts['build'] ?? 0;
+        } elseif (
+            // Accept plain numeric format returned by newer Firebird Docker images: "5.0.3.1683", "3.0.13.33818"
+            preg_match(
+                '/^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+)(?:\.(?P<build>\d+))?)?)?$/',
+                $version,
+                $versionParts,
+            ) === 1
+        ) {
+            $majorVersion = $versionParts['major'];
+            $minorVersion = $versionParts['minor'] ?? 0;
+            $patchVersion = $versionParts['patch'] ?? 0;
+            $buildVersion = $versionParts['build'] ?? 0;
+        } else {
             throw Exception::invalidPlatformVersionSpecified(
                 $version,
                 'LI|WI-V<major_version>.<minor_version>.<patch_version>.<build_version>',
             );
         }
 
-        $majorVersion = $versionParts['major'];
-        $minorVersion = $versionParts['minor'] ?? 0;
-        $patchVersion = $versionParts['patch'] ?? 0;
-        $buildVersion = $versionParts['build'] ?? 0;
-        $version      = $majorVersion . '.' . $minorVersion . '.' . $patchVersion . '.' . $buildVersion;
+        $version = $majorVersion . '.' . $minorVersion . '.' . $patchVersion . '.' . $buildVersion;
 
         $platform = match (true) {
             version_compare($version, '6.0', '>=') => new Firebird5Platform(),

--- a/tests/Test/Driver/VersionAwarePlatformDriverTest.php
+++ b/tests/Test/Driver/VersionAwarePlatformDriverTest.php
@@ -42,6 +42,7 @@ class VersionAwarePlatformDriverTest extends TestCase
      */
     public static function firebirdVersionProvider(): Iterator
     {
+        // Legacy "LI|WI-V..." format (older Firebird installations)
         yield ['WI-V2.1.4.18393', FirebirdPlatform::class];
         yield ['LI-V2.1.4.18393', FirebirdPlatform::class];
         yield ['LI-V2.999.999.99999', FirebirdPlatform::class];
@@ -50,6 +51,12 @@ class VersionAwarePlatformDriverTest extends TestCase
         yield ['LI-V4.1.2.34567', Firebird4Platform::class];
         yield ['LI-V5.1.2.34567', Firebird5Platform::class];
         yield ['LI-V6.1.2.34567', Firebird5Platform::class];
+        // Plain numeric format returned by newer Firebird Docker images (firebirdsql/firebird:3, :4, :5)
+        yield ['2.5.9.27139', FirebirdPlatform::class];
+        yield ['3.0.13.33818', Firebird3Platform::class];
+        yield ['4.0.5.3116', Firebird4Platform::class];
+        yield ['5.0.3.1683', Firebird5Platform::class];
+        yield ['6.0.0.1', Firebird5Platform::class];
     }
 
     /**


### PR DESCRIPTION
## Problem

Closes #82 — Unblocks PR #81

All CI matrix jobs (PHP 8.3/8.4 × Firebird 3.0/4.0/5.0) were failing with:

```
Doctrine\DBAL\Exception: Invalid platform version "5.0.3.1683" specified.
The platform version has to be specified in the format:
"LI|WI-V<major_version>.<minor_version>.<patch_version>.<build_version>".
```

**Root cause**: Newer `firebirdsql/firebird` Docker images (v3, v4, v5) return plain numeric version strings (e.g. `3.0.13.33818`, `5.0.3.1683`) instead of the legacy `LI|WI-V...` format. The `createDatabasePlatformForVersion()` regex only matched the legacy format, causing 598+ errors per job.

## Fix

Extended the version parser in `FirebirdDriver::createDatabasePlatformForVersion()` to accept both formats:

| Format | Example | Source |
|--------|---------|--------|
| Legacy | `LI-V3.0.13.33818`, `WI-V4.0.5.3116` | Older Firebird installations |
| Plain  | `3.0.13.33818`, `5.0.3.1683` | Newer `firebirdsql/firebird` Docker images |

Both formats extract the same major/minor/patch/build components and route to the correct platform class.

## Tests

Added 5 new test cases to `VersionAwarePlatformDriverTest` covering plain numeric versions for all supported Firebird versions (2.x → 6.x).

```
OK (14 tests, 14 assertions)
```

PHPStan Level 8: ✅ No errors

## Impact

- Fixes all 6 matrix jobs on `3.0.x`
- Unblocks PR #81 (php-firebird v7.2.0 compat) from merging