### PR TITLE
feat(middleware): CharsetMiddleware — transparent Firebird charset conversion (WIN1252/UTF-8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`CharsetMiddleware`** — transparent charset conversion middleware for non-UTF-8 Firebird databases
+  - `src/Driver/Firebird/Middleware/CharsetMiddleware` — top-level DBAL middleware (implements `Doctrine\DBAL\Driver\Middleware`)
+  - `src/Driver/Firebird/Middleware/CharsetConnectionMiddleware` — encodes query-level string parameters (PHP→DB)
+  - `src/Driver/Firebird/Middleware/CharsetStatementMiddleware` — encodes `bindValue()` and execute params (PHP→DB); wraps Result
+  - `src/Driver/Firebird/Middleware/CharsetResultMiddleware` — decodes all `fetch*()` string results (DB→PHP)
+  - Default encodings: `databaseEncoding: 'Windows-1252'`, `phpEncoding: 'UTF-8'` (covers WIN1252/ISO8859_1 Firebird databases)
+  - Custom encoding pairs supported (e.g. `ISO-8859-1`/`UTF-8`)
+  - Ported and generalized from `satag-amicron-entity-bundle` for all Firebird users
+- **`ext-mbstring`** added to `require` (`mb_convert_encoding` dependency)
+- **`tests/Test/Unit/Driver/Middleware/CharsetMiddlewareTest`** — 15 unit tests, 36 assertions
+
 ## [3.10.1] - 2026-03-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -201,6 +201,67 @@ doctrine:
 - Type mismatch (non-integer values)
 - Out of range (<1 or >8191)
 
+### CharsetMiddleware - Transparent Charset Conversion
+
+Many Firebird databases use a non-UTF-8 wire charset (e.g. `ISO8859_1` / `WIN1252`). The `CharsetMiddleware` converts string values transparently between your PHP application encoding and the Firebird wire encoding at the DBAL driver level - no manual `iconv`/`mb_convert_encoding` calls needed in application code.
+
+**Defaults:** `databaseEncoding: 'Windows-1252'` and `phpEncoding: 'UTF-8'` covers the most common case (Amicron ERP and other WIN1252 Firebird databases).
+
+#### Symfony Configuration (DoctrineBundle service)
+
+```xml
+<!-- config/services.xml -->
+<service id="Satag\DoctrineFirebirdDriver\Driver\Firebird\Middleware\CharsetMiddleware">
+    <tag name="doctrine.middleware"/>
+</service>
+```
+
+```yaml
+# config/services.yaml
+Satag\DoctrineFirebirdDriver\Driver\Firebird\Middleware\CharsetMiddleware:
+    tags:
+        - { name: doctrine.middleware }
+```
+
+#### Standalone PHP Configuration
+
+```php
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\DriverManager;
+use Satag\DoctrineFirebirdDriver\Driver\Firebird\Middleware\CharsetMiddleware;
+
+$config = new Configuration();
+$config->setMiddlewares([
+    new CharsetMiddleware(), // defaults: WIN1252 → UTF-8
+]);
+
+$connection = DriverManager::getConnection([
+    'driver_class' => \Satag\DoctrineFirebirdDriver\Driver\Firebird\Driver::class,
+    'host'         => 'localhost',
+    'dbname'       => '/path/to/database.fdb',
+    'user'         => 'SYSDBA',
+    'password'     => 'masterkey',
+    'charset'      => 'WIN1252',
+], $config);
+```
+
+#### Custom Encoding Pair
+
+```php
+// ISO-8859-1 database, UTF-8 application
+$middleware = new CharsetMiddleware(databaseEncoding: 'ISO-8859-1', phpEncoding: 'UTF-8');
+
+// UTF-8 database (no conversion needed - use identity pair)
+$middleware = new CharsetMiddleware(databaseEncoding: 'UTF-8', phpEncoding: 'UTF-8');
+```
+
+**How it works:**
+- `bindValue()` / execute params: PHP encoding → database encoding before sending to Firebird
+- `fetch*()` results: database encoding → PHP encoding after receiving from Firebird
+- Non-string values (int, float, null, bool) pass through unchanged
+
+**Requires:** `ext-mbstring` (declared in `composer.json`)
+
 # Testing
 
 The project includes comprehensive test coverage across **Firebird 3.0, 4.0, and 5.0** with unit, functional, and integration tests.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "satag/doctrine-firebird-driver",
+    "version": "3.10.1",
     "type": "library",
     "description": "Doctrine DBAL/ORM driver for Firebird SQL 3.0 and newer",
     "license": "MIT",
@@ -65,6 +66,7 @@
     "require": {
         "php": "^8.2",
         "ext-firebird": "^7.2.0",
+        "ext-mbstring": "*",
         "composer-runtime-api": "^2",
         "doctrine/dbal": "^3.10",
         "symfony/polyfill-php82": "^1.31",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "satag/doctrine-firebird-driver",
-    "version": "3.10.1",
     "type": "library",
     "description": "Doctrine DBAL/ORM driver for Firebird SQL 3.0 and newer",
     "license": "MIT",

--- a/src/Driver/Firebird/Middleware/CharsetConnectionMiddleware.php
+++ b/src/Driver/Firebird/Middleware/CharsetConnectionMiddleware.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Satag\DoctrineFirebirdDriver\Driver\Firebird\Middleware;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\ParameterType;
+use Override;
+
+use function is_string;
+use function mb_convert_encoding;
+
+/**
+ * Wraps every prepared Statement in CharsetStatementMiddleware and encodes
+ * values passed to quote() from the PHP encoding to the database encoding.
+ */
+final class CharsetConnectionMiddleware extends AbstractConnectionMiddleware
+{
+    public function __construct(
+        Connection $connection,
+        private readonly string $databaseEncoding,
+        private readonly string $phpEncoding,
+    ) {
+        parent::__construct($connection);
+    }
+
+    /**
+     * Prepare a statement and wrap it so all bound parameters are encoded.
+     */
+    #[Override]
+    public function prepare(string $sql): Statement
+    {
+        return new CharsetStatementMiddleware(
+            parent::prepare($sql),
+            $this->databaseEncoding,
+            $this->phpEncoding,
+        );
+    }
+
+    /**
+     * Encode string values from PHP encoding to database encoding before quoting.
+     *
+     * Note: signature uses untyped $value/$type and no return type hint to
+     * match the parent AbstractConnectionMiddleware which was written before
+     * PHP 8 union types.
+     *
+     * {@inheritDoc}
+     *
+     * @param mixed $value
+     * @param mixed $type
+     *
+     * @return mixed
+     */
+    #[Override]
+    public function quote($value, $type = ParameterType::STRING)
+    {
+        if (is_string($value)) {
+            $value = mb_convert_encoding($value, $this->databaseEncoding, $this->phpEncoding);
+        }
+
+        return parent::quote($value, $type);
+    }
+}

--- a/src/Driver/Firebird/Middleware/CharsetMiddleware.php
+++ b/src/Driver/Firebird/Middleware/CharsetMiddleware.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Satag\DoctrineFirebirdDriver\Driver\Firebird\Middleware;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use Override;
+use SensitiveParameter;
+
+/**
+ * DBAL Middleware that makes non-UTF-8 Firebird wire encoding fully transparent.
+ *
+ * Firebird databases are often configured with a non-UTF-8 charset (e.g.
+ * ISO8859_1 / Windows-1252, WIN1252). This middleware transparently converts
+ * string values between the PHP application encoding (default: UTF-8) and the
+ * Firebird wire encoding (default: Windows-1252) at the DBAL driver level.
+ *
+ * Usage with DoctrineBundle (service.xml / services.yaml):
+ * ```xml
+ * <service id="Satag\DoctrineFirebirdDriver\Driver\Firebird\Middleware\CharsetMiddleware">
+ *     <tag name="doctrine.middleware"/>
+ * </service>
+ * ```
+ *
+ * Usage with custom encodings:
+ * ```php
+ * $middleware = new CharsetMiddleware(databaseEncoding: 'ISO-8859-1', phpEncoding: 'UTF-8');
+ * $config->setMiddlewares([$middleware]);
+ * ```
+ *
+ * Flow:
+ *   PHP ($phpEncoding) → CharsetStatementMiddleware::bindValue() → $databaseEncoding → Firebird
+ *   Firebird → $databaseEncoding → CharsetResultMiddleware::fetch*() → $phpEncoding → PHP
+ */
+final class CharsetMiddleware implements MiddlewareInterface
+{
+    /**
+     * @param string $databaseEncoding The encoding used by the Firebird database on the wire
+     *                                 (e.g. 'Windows-1252' for ISO8859_1/WIN1252 charset).
+     * @param string $phpEncoding      The encoding used by the PHP application (typically 'UTF-8').
+     */
+    public function __construct(
+        private readonly string $databaseEncoding = 'Windows-1252',
+        private readonly string $phpEncoding = 'UTF-8',
+    ) {
+    }
+
+    public function wrap(Driver $driver): Driver
+    {
+        $databaseEncoding = $this->databaseEncoding;
+        $phpEncoding      = $this->phpEncoding;
+
+        return new class ($driver, $databaseEncoding, $phpEncoding) extends AbstractDriverMiddleware {
+            public function __construct(
+                Driver $driver,
+                private readonly string $databaseEncoding,
+                private readonly string $phpEncoding,
+            ) {
+                parent::__construct($driver);
+            }
+
+            /**
+             * Connect and wrap the native connection in CharsetConnectionMiddleware.
+             *
+             * {@inheritDoc}
+             */
+            #[Override]
+            public function connect(
+                #[SensitiveParameter]
+                array $params,
+            ): CharsetConnectionMiddleware {
+                return new CharsetConnectionMiddleware(
+                    parent::connect($params),
+                    $this->databaseEncoding,
+                    $this->phpEncoding,
+                );
+            }
+        };
+    }
+}

--- a/src/Driver/Firebird/Middleware/CharsetResultMiddleware.php
+++ b/src/Driver/Firebird/Middleware/CharsetResultMiddleware.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Satag\DoctrineFirebirdDriver\Driver\Firebird\Middleware;
+
+use Doctrine\DBAL\Driver\Middleware\AbstractResultMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use Override;
+
+use function array_map;
+use function array_values;
+use function is_array;
+use function is_string;
+use function mb_convert_encoding;
+
+/**
+ * Decodes all string values returned from Firebird (database encoding) to the
+ * PHP application encoding (typically UTF-8).
+ *
+ * This middleware wraps every Result object so that raw DBAL fetch calls
+ * (fetchAssociative, fetchNumeric, fetchOne, etc.) transparently return
+ * strings in the PHP encoding regardless of the database wire encoding.
+ */
+final class CharsetResultMiddleware extends AbstractResultMiddleware
+{
+    public function __construct(
+        Result $result,
+        private readonly string $databaseEncoding,
+        private readonly string $phpEncoding,
+    ) {
+        parent::__construct($result);
+    }
+
+    /** @return list<mixed>|false */
+    #[Override]
+    public function fetchNumeric(): array|false
+    {
+        $row = parent::fetchNumeric();
+
+        return is_array($row) ? array_values($this->decodeRow($row)) : $row;
+    }
+
+    /** @return array<string, mixed>|false */
+    #[Override]
+    public function fetchAssociative(): array|false
+    {
+        $row = parent::fetchAssociative();
+
+        if (! is_array($row)) {
+            return $row;
+        }
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = $this->decodeRow($row);
+
+        return $decoded;
+    }
+
+    #[Override]
+    public function fetchOne(): mixed
+    {
+        $value = parent::fetchOne();
+
+        return $this->decodeValue($value);
+    }
+
+    /** @return list<list<mixed>> */
+    #[Override]
+    public function fetchAllNumeric(): array
+    {
+        return array_map(
+            fn (array $row): array => array_values($this->decodeRow($row)),
+            parent::fetchAllNumeric(),
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    #[Override]
+    public function fetchAllAssociative(): array
+    {
+        return array_map(
+            fn (array $row): array => $this->decodeRow($row),
+            parent::fetchAllAssociative(),
+        );
+    }
+
+    /** @return list<mixed> */
+    #[Override]
+    public function fetchFirstColumn(): array
+    {
+        return array_map(
+            fn (mixed $value): mixed => $this->decodeValue($value),
+            parent::fetchFirstColumn(),
+        );
+    }
+
+    /**
+     * Decode all string values in a row from database encoding to PHP encoding.
+     *
+     * @param array<int|string, mixed> $row
+     *
+     * @return array<int|string, mixed>
+     */
+    private function decodeRow(array $row): array
+    {
+        foreach ($row as $key => $value) {
+            $row[$key] = $this->decodeValue($value);
+        }
+
+        return $row;
+    }
+
+    /**
+     * Decode a single value from database encoding to PHP encoding if it is a string.
+     * Non-string values (int, float, null, bool, objects) pass through unchanged.
+     */
+    private function decodeValue(mixed $value): mixed
+    {
+        if (! is_string($value)) {
+            return $value;
+        }
+
+        return mb_convert_encoding($value, $this->phpEncoding, $this->databaseEncoding);
+    }
+}

--- a/src/Driver/Firebird/Middleware/CharsetStatementMiddleware.php
+++ b/src/Driver/Firebird/Middleware/CharsetStatementMiddleware.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Satag\DoctrineFirebirdDriver\Driver\Firebird\Middleware;
+
+use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
+use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\ParameterType;
+use Override;
+
+use function is_string;
+use function mb_convert_encoding;
+
+/**
+ * Encodes all string parameters from the PHP encoding to the database encoding
+ * before sending to Firebird.
+ *
+ * This middleware wraps every Statement so that raw DBAL bindValue() calls
+ * (and execute() with inline params) transparently encode strings to the
+ * database wire encoding, regardless of whether the ORM type system is used.
+ */
+final class CharsetStatementMiddleware extends AbstractStatementMiddleware
+{
+    public function __construct(
+        Statement $statement,
+        private readonly string $databaseEncoding,
+        private readonly string $phpEncoding,
+    ) {
+        parent::__construct($statement);
+    }
+
+    /**
+     * Encode string parameters from PHP encoding to database encoding before binding.
+     *
+     * Only STRING and ASCII parameter types are encoded. Numeric, boolean,
+     * binary, and large-object types pass through unchanged.
+     *
+     * Note: signature uses untyped $param/$value/$type to match the parent
+     * AbstractStatementMiddleware which was written before PHP 8 union types.
+     *
+     * @param int|string $param
+     * @param mixed      $value
+     * @param mixed      $type
+     */
+    #[Override]
+    public function bindValue($param, $value, $type = ParameterType::STRING): bool
+    {
+        if (is_string($value) && ($type === ParameterType::STRING || $type === ParameterType::ASCII)) {
+            $value = mb_convert_encoding($value, $this->databaseEncoding, $this->phpEncoding);
+        }
+
+        return parent::bindValue($param, $value, $type);
+    }
+
+    /**
+     * Execute the statement and wrap the result in CharsetResultMiddleware.
+     *
+     * Note: signature uses untyped $params to match the parent
+     * AbstractStatementMiddleware which was written before PHP 8 union types.
+     *
+     * @param array<int|string, mixed>|null $params
+     */
+    #[Override]
+    public function execute($params = null): ResultInterface
+    {
+        // If inline params are passed (deprecated path), encode them first
+        if ($params !== null) {
+            foreach ($params as $key => $value) {
+                if (! is_string($value)) {
+                    continue;
+                }
+
+                $params[$key] = mb_convert_encoding($value, $this->databaseEncoding, $this->phpEncoding);
+            }
+        }
+
+        return new CharsetResultMiddleware(
+            parent::execute($params),
+            $this->databaseEncoding,
+            $this->phpEncoding,
+        );
+    }
+}

--- a/tests/Test/Unit/Driver/Middleware/CharsetMiddlewareTest.php
+++ b/tests/Test/Unit/Driver/Middleware/CharsetMiddlewareTest.php
@@ -1,0 +1,304 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Satag\DoctrineFirebirdDriver\Test\Unit\Driver\Middleware;
+
+use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
+use Doctrine\DBAL\ParameterType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Satag\DoctrineFirebirdDriver\Driver\Firebird\Middleware\CharsetMiddleware;
+use Satag\DoctrineFirebirdDriver\Driver\Firebird\Middleware\CharsetResultMiddleware;
+use Satag\DoctrineFirebirdDriver\Driver\Firebird\Middleware\CharsetStatementMiddleware;
+
+/**
+ * Unit tests for the charset middleware encoding/decoding logic.
+ *
+ * These tests verify that:
+ * - String parameters are encoded PHP encoding → database encoding before being sent to Firebird
+ * - String results are decoded database encoding → PHP encoding after being received from Firebird
+ * - Non-string values (int, float, null, bool) pass through unchanged
+ * - Custom encoding pairs work correctly (not just Windows-1252/UTF-8)
+ */
+#[CoversClass(CharsetMiddleware::class)]
+#[CoversClass(CharsetResultMiddleware::class)]
+#[CoversClass(CharsetStatementMiddleware::class)]
+class CharsetMiddlewareTest extends TestCase
+{
+    // =========================================================================
+    // CharsetResultMiddleware - decoding (DB → PHP), default Windows-1252/UTF-8
+    // =========================================================================
+
+    public function testDecodesFetchAssociativeStrings(): void
+    {
+        $win1252Row = [
+            'NAME'  => \mb_convert_encoding('Faßbrause', 'Windows-1252', 'UTF-8'),
+            'PREIS' => \mb_convert_encoding('30€', 'Windows-1252', 'UTF-8'),
+            'LFDNR' => 42,
+        ];
+
+        $innerResult = $this->createResultMock();
+        $innerResult->method('fetchAssociative')->willReturn($win1252Row);
+
+        $middleware = new CharsetResultMiddleware($innerResult, 'Windows-1252', 'UTF-8');
+        $row        = $middleware->fetchAssociative();
+
+        self::assertIsArray($row);
+        self::assertSame('Faßbrause', $row['NAME']);
+        self::assertSame('30€', $row['PREIS']);
+        self::assertSame(42, $row['LFDNR']); // int passes through unchanged
+    }
+
+    public function testDecodesFetchNumericStrings(): void
+    {
+        $win1252Row = [
+            \mb_convert_encoding('Grüner Tee', 'Windows-1252', 'UTF-8'),
+            99,
+            null,
+        ];
+
+        $innerResult = $this->createResultMock();
+        $innerResult->method('fetchNumeric')->willReturn($win1252Row);
+
+        $middleware = new CharsetResultMiddleware($innerResult, 'Windows-1252', 'UTF-8');
+        $row        = $middleware->fetchNumeric();
+
+        self::assertIsArray($row);
+        self::assertSame('Grüner Tee', $row[0]);
+        self::assertSame(99, $row[1]);
+        self::assertNull($row[2]);
+    }
+
+    public function testDecodesFetchOneString(): void
+    {
+        $win1252Value = \mb_convert_encoding('Müller & Söhne', 'Windows-1252', 'UTF-8');
+
+        $innerResult = $this->createResultMock();
+        $innerResult->method('fetchOne')->willReturn($win1252Value);
+
+        $middleware = new CharsetResultMiddleware($innerResult, 'Windows-1252', 'UTF-8');
+        $value      = $middleware->fetchOne();
+
+        self::assertSame('Müller & Söhne', $value);
+    }
+
+    public function testDecodesFetchAllAssociative(): void
+    {
+        $rows = [
+            ['NAME' => \mb_convert_encoding('Ärger', 'Windows-1252', 'UTF-8'), 'ID' => 1],
+            ['NAME' => \mb_convert_encoding('Öl', 'Windows-1252', 'UTF-8'), 'ID' => 2],
+        ];
+
+        $innerResult = $this->createResultMock();
+        $innerResult->method('fetchAllAssociative')->willReturn($rows);
+
+        $middleware = new CharsetResultMiddleware($innerResult, 'Windows-1252', 'UTF-8');
+        $result     = $middleware->fetchAllAssociative();
+
+        self::assertSame('Ärger', $result[0]['NAME']);
+        self::assertSame(1, $result[0]['ID']);
+        self::assertSame('Öl', $result[1]['NAME']);
+    }
+
+    public function testDecodesFetchFirstColumn(): void
+    {
+        $values = [
+            \mb_convert_encoding('Straße', 'Windows-1252', 'UTF-8'),
+            \mb_convert_encoding('Wörth', 'Windows-1252', 'UTF-8'),
+        ];
+
+        $innerResult = $this->createResultMock();
+        $innerResult->method('fetchFirstColumn')->willReturn($values);
+
+        $middleware = new CharsetResultMiddleware($innerResult, 'Windows-1252', 'UTF-8');
+        $result     = $middleware->fetchFirstColumn();
+
+        self::assertSame('Straße', $result[0]);
+        self::assertSame('Wörth', $result[1]);
+    }
+
+    public function testNonStringValuesPassThroughUnchanged(): void
+    {
+        $row = [
+            'INT_COL'   => 42,
+            'FLOAT_COL' => 3.14,
+            'NULL_COL'  => null,
+            'BOOL_COL'  => true,
+        ];
+
+        $innerResult = $this->createResultMock();
+        $innerResult->method('fetchAssociative')->willReturn($row);
+
+        $middleware = new CharsetResultMiddleware($innerResult, 'Windows-1252', 'UTF-8');
+        $result     = $middleware->fetchAssociative();
+
+        self::assertIsArray($result);
+        self::assertSame(42, $result['INT_COL']);
+        self::assertSame(3.14, $result['FLOAT_COL']);
+        self::assertNull($result['NULL_COL']);
+        self::assertTrue($result['BOOL_COL']);
+    }
+
+    public function testReturnsFalseWhenNoMoreRows(): void
+    {
+        $innerResult = $this->createResultMock();
+        $innerResult->method('fetchAssociative')->willReturn(false);
+        $innerResult->method('fetchNumeric')->willReturn(false);
+
+        $middleware = new CharsetResultMiddleware($innerResult, 'Windows-1252', 'UTF-8');
+
+        self::assertFalse($middleware->fetchAssociative());
+        self::assertFalse($middleware->fetchNumeric());
+    }
+
+    // =========================================================================
+    // CharsetStatementMiddleware - encoding (PHP → DB), default Windows-1252/UTF-8
+    // =========================================================================
+
+    public function testEncodesStringParameterOnBindValue(): void
+    {
+        $capturedValue = null;
+
+        $innerStatement = $this->createStatementMock();
+        $innerStatement
+            ->expects(self::once())
+            ->method('bindValue')
+            ->willReturnCallback(static function (mixed $param, mixed $value, mixed $type) use (&$capturedValue): bool {
+                $capturedValue = $value;
+
+                return true;
+            });
+
+        $middleware = new CharsetStatementMiddleware($innerStatement, 'Windows-1252', 'UTF-8');
+        $middleware->bindValue(1, 'Faßbrause für 30€?', ParameterType::STRING);
+
+        $expected = \mb_convert_encoding('Faßbrause für 30€?', 'Windows-1252', 'UTF-8');
+        self::assertSame($expected, $capturedValue);
+    }
+
+    public function testDoesNotEncodeNonStringParameterOnBindValue(): void
+    {
+        $capturedValue = null;
+
+        $innerStatement = $this->createStatementMock();
+        $innerStatement
+            ->expects(self::once())
+            ->method('bindValue')
+            ->willReturnCallback(static function (mixed $param, mixed $value, mixed $type) use (&$capturedValue): bool {
+                $capturedValue = $value;
+
+                return true;
+            });
+
+        $middleware = new CharsetStatementMiddleware($innerStatement, 'Windows-1252', 'UTF-8');
+        $middleware->bindValue(1, 42, ParameterType::INTEGER);
+
+        self::assertSame(42, $capturedValue);
+    }
+
+    public function testDoesNotEncodeNullParameterOnBindValue(): void
+    {
+        $capturedValue = 'sentinel';
+
+        $innerStatement = $this->createStatementMock();
+        $innerStatement
+            ->expects(self::once())
+            ->method('bindValue')
+            ->willReturnCallback(static function (mixed $param, mixed $value, mixed $type) use (&$capturedValue): bool {
+                $capturedValue = $value;
+
+                return true;
+            });
+
+        $middleware = new CharsetStatementMiddleware($innerStatement, 'Windows-1252', 'UTF-8');
+        $middleware->bindValue(1, null, ParameterType::STRING);
+
+        self::assertNull($capturedValue);
+    }
+
+    public function testSpecialCharactersRoundTripWindowsToUtf8(): void
+    {
+        $specialChars = [
+            'Faßbrause für 30€?',
+            'Ärger mit Öl und Übergabe',
+            'Straße 123, Wörth am Rhein',
+            'Müller & Söhne GmbH',
+        ];
+
+        foreach ($specialChars as $input) {
+            $encoded = \mb_convert_encoding($input, 'Windows-1252', 'UTF-8');
+            $decoded = \mb_convert_encoding($encoded, 'UTF-8', 'Windows-1252');
+            self::assertSame($input, $decoded, "Round-trip failed for: {$input}");
+        }
+    }
+
+    // =========================================================================
+    // Configurable encoding - ISO-8859-1 / UTF-8
+    // =========================================================================
+
+    public function testCustomEncodingIso88591DecodesFetchOne(): void
+    {
+        $iso88591Value = \mb_convert_encoding('Müller', 'ISO-8859-1', 'UTF-8');
+
+        $innerResult = $this->createResultMock();
+        $innerResult->method('fetchOne')->willReturn($iso88591Value);
+
+        $middleware = new CharsetResultMiddleware($innerResult, 'ISO-8859-1', 'UTF-8');
+        $value      = $middleware->fetchOne();
+
+        self::assertSame('Müller', $value);
+    }
+
+    public function testCustomEncodingIso88591EncodesBindValue(): void
+    {
+        $capturedValue = null;
+
+        $innerStatement = $this->createStatementMock();
+        $innerStatement
+            ->expects(self::once())
+            ->method('bindValue')
+            ->willReturnCallback(static function (mixed $param, mixed $value, mixed $type) use (&$capturedValue): bool {
+                $capturedValue = $value;
+
+                return true;
+            });
+
+        $middleware = new CharsetStatementMiddleware($innerStatement, 'ISO-8859-1', 'UTF-8');
+        $middleware->bindValue(1, 'Müller', ParameterType::STRING);
+
+        $expected = \mb_convert_encoding('Müller', 'ISO-8859-1', 'UTF-8');
+        self::assertSame($expected, $capturedValue);
+    }
+
+    public function testCharsetMiddlewareDefaultEncodingsAreWindowsAndUtf8(): void
+    {
+        $middleware = new CharsetMiddleware();
+
+        // Verify the middleware can be instantiated with defaults (no exception)
+        self::assertInstanceOf(CharsetMiddleware::class, $middleware);
+    }
+
+    public function testCharsetMiddlewareAcceptsCustomEncodings(): void
+    {
+        $middleware = new CharsetMiddleware(databaseEncoding: 'ISO-8859-1', phpEncoding: 'UTF-8');
+
+        self::assertInstanceOf(CharsetMiddleware::class, $middleware);
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private function createResultMock(): ResultInterface&MockObject
+    {
+        return $this->createMock(ResultInterface::class);
+    }
+
+    private function createStatementMock(): StatementInterface&MockObject
+    {
+        return $this->createMock(StatementInterface::class);
+    }
+}


### PR DESCRIPTION
## Summary

Ports and generalizes `CharsetMiddleware` from `satag-amicron-entity-bundle` to `doctrine-firebird-driver` for all Firebird users.

Many Firebird databases use a non-UTF-8 wire charset (`ISO8859_1` / `WIN1252`). This middleware converts string values transparently between the PHP application encoding and the Firebird wire encoding at the DBAL driver level — no manual `iconv`/`mb_convert_encoding` calls needed in application code.

## New classes (`src/Driver/Firebird/Middleware/`)

| Class | Role |
|-------|------|
| `CharsetMiddleware` | Top-level DBAL middleware — default: `Windows-1252` → `UTF-8` |
| `CharsetConnectionMiddleware` | Encodes query-level string params (PHP→DB) |
| `CharsetStatementMiddleware` | Encodes `bindValue()`/execute params (PHP→DB); wraps Result |
| `CharsetResultMiddleware` | Decodes all `fetch*()` string results (DB→PHP) |

Non-string values (`int`, `float`, `null`, `bool`) pass through unchanged.

## Usage

```php
// Standalone PHP
$config = new Configuration();
$config->setMiddlewares([new CharsetMiddleware()]); // defaults: WIN1252 → UTF-8
```

```yaml
# Symfony — config/services.yaml
Satag\DoctrineFirebirdDriver\Driver\Firebird\Middleware\CharsetMiddleware:
    tags:
        - { name: doctrine.middleware }
```

Custom encoding pair:
```php
$middleware = new CharsetMiddleware(databaseEncoding: 'ISO-8859-1', phpEncoding: 'UTF-8');
```

## Tests

- `tests/Test/Unit/Driver/Middleware/CharsetMiddlewareTest` — **15 tests, 36 assertions**
- Covers: fetchAssociative, fetchNumeric, fetchOne, fetchAllAssociative, fetchFirstColumn, non-string passthrough, bindValue encoding, null passthrough, round-trip special chars, custom ISO-8859-1/UTF-8, CharsetMiddleware instantiation

## Quality

- PHPStan Level 8: ✅ 0 errors
- 15/15 unit tests passing
- `ext-mbstring` added to `composer.json` `require`

## Target release: v3.11.0