### PR TITLE
Remove redundant symfony/polyfill-php82 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,6 @@
         "doctrine/dbal": "^4.4",
         "symfony/polyfill-intl-grapheme": "^1.33",
         "symfony/polyfill-intl-normalizer": "^1.33",
-        "symfony/polyfill-php82": "^1.33",
         "symfony/polyfill-php83": "^1.33",
         "symfony/polyfill-php84": "^1.33",
         "symfony/polyfill-php85": "^1.33"


### PR DESCRIPTION
This package depends on `symfony/polyfill-php82`, but also `php: ^8.2`, so the polyfill requirement doesn't seem necessary anymore?