### PR TITLE
docs: add No-Retag Policy to BRANCHING.md

### DIFF
--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -85,6 +85,18 @@ git tag -a vX.Y.Z -m "chore(release): vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
+## No-Retag Policy
+
+**Tags MUST NOT be force-pushed or deleted after publication.**
+
+Packagist enforces [version immutability](https://packagist.org/about/version-immutability):
+once a stable version is crawled, its source reference is locked. Retagging causes
+Packagist to block the update, leaving downstream consumers with a stale commit.
+
+If a tagged release has a regression, **publish a new version** (e.g., `v1.2.4`
+after `v1.2.3`) instead of retagging. GitHub tag protection rules prevent
+accidental force-pushes.
+
 ---
 
 ## Commit Convention


### PR DESCRIPTION
## Summary

Adds a **No-Retag Policy** section to `docs/BRANCHING.md`, placed after the existing "Tag Procedure" section.

This is part **D** of issue #111.

## Context

The `v3.13.0-RC.1` tag was force-moved (retagged) after Packagist's initial crawl. Packagist's [version-immutability policy](https://packagist.org/about/version-immutability) blocked the update, so the published version was locked at the wrong commit (`4b105b1`, a CI fix) instead of the M3 migration commit (`5a623f3`). Downstream consumers requiring `^3.13.0` got the stale commit.

## What this PR adds

A documented rule that tags must never be force-pushed or deleted after publication, with guidance to publish a new version instead of retagging. This complements the **Tag Immutability** GitHub ruleset (target=`tag`, glob `refs/tags/v*`, blocks deletion + non-fast-forward) created in #111 part C.

## Related

- Refs #111 (does not auto-close; the issue spans A-D, and the Packagist soft-delete is a manual maintainer action)
- Working release `v3.13.0` (stable) already published from `3.10.x @ c854af2`
- Ruleset "Tag Immutability" (id 18477048) already active