### PR TITLE
feat: add forceNewConnection option and fix role parameter (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`forceNewConnection` option** (#114): New connection parameter that bypasses
+  php-firebird's default connection reuse by passing `FBIRD_CONNECT_FORCE_NEW` to
+  `fbird_connect()`. Eliminates a race condition in test suites that boot/shutdown
+  Doctrine kernels between tests (PHPUnit, Pest) where GC-collected destructors
+  close reused links out from under new connections. Default: `false` (production
+  behavior unchanged). Configure via array params (`forceNewConnection => true`)
+  or DSN query parameter (`?forceNewConnection=1`). Persistent connections are
+  unaffected (separate pool, no reuse race).
+
+### Fixed
+- **`role` parameter silently ignored**: `Driver::connect()` now passes
+  `$params['role']` to `fbird_connect()` and `fbird_pconnect()` as the 7th
+  argument (`$role`). Previously the `role` parameter was documented and parsed
+  by `DsnParser` but never forwarded to the native function. Verified via
+  `SELECT CURRENT_ROLE FROM RDB$DATABASE` returning the expected role name.
+
 ## [3.14.0] - 2026-07-07 - php-firebird v12.0.0 stable integration
 
 ### Changed

--- a/docs/DSN.md
+++ b/docs/DSN.md
@@ -48,6 +48,12 @@ firebird://SYSDBA:masterkey@localhost:3050/var/db/myapp.fdb
 firebird://user:password@hostname:port/path/to/database.fdb?charset=UTF8&role=ADMIN
 ```
 
+Example with `forceNewConnection` (test/CI environments):
+
+```text
+firebird://SYSDBA:masterkey@localhost:3050/var/db/myapp.fdb?charset=UTF8&forceNewConnection=1
+```
+
 Supported query parameters:
 
 | Parameter | Description | Default |
@@ -55,6 +61,7 @@ Supported query parameters:
 | `charset` | Character set (e.g. `UTF8`, `WIN1252`) | `UTF8` |
 | `role` | SQL role name | none |
 | `persistent` | Use persistent connections (`1`/`0`) | `0` |
+| `forceNewConnection` | Force a new connection, bypassing connection reuse (`1`/`0`) | `0` |
 
 #### Service name (Firebird service manager path)
 
@@ -114,6 +121,7 @@ $connection = DriverManager::getConnection([
 | `charset` | `string` | Character set (default: `UTF8`) |
 | `role` | `string` | SQL role name (optional) |
 | `persistent` | `bool` | Use `fbird_pconnect()` instead of `fbird_connect()` |
+| `forceNewConnection` | `bool` | Force a new connection via `FBIRD_CONNECT_FORCE_NEW` (default: `false`) |
 | `driverOptions` | `array` | Driver-specific options (see below) |
 
 ### Driver Options (`driverOptions`)

--- a/specs/002-force-new-connection/spec.md
+++ b/specs/002-force-new-connection/spec.md
@@ -116,8 +116,11 @@ verification against a real DB).
 - **FR-004**: `forceNewConnection` MUST be ignored for persistent connections
   (`fbird_pconnect()` has no `$flags` parameter; persistent connections use a separate
   pool and are not affected by the reuse race).
-- **FR-005**: `Driver::connect()` MUST pass `$params['role'] ?? null` as the 7th argument
-  (`$role`) to both `fbird_connect()` and `fbird_pconnect()`.
+- **FR-005**: `Driver::connect()` MUST pass `$params['role'] ?? ''` as the 7th argument
+  (`$role`) to both `fbird_connect()` and `fbird_pconnect()`. An empty string is
+  used instead of `null` because the C implementation (`zend_parse_parameters`
+  with format `s`) requires a string, not null - despite the stubs declaring
+  `?string`.
 - **FR-006**: The DSN query parameter `forceNewConnection=1` MUST be supported without
   changes to `DsnParser` (Doctrine's `parse_str` + `array_merge` already delivers it
   into `$params`).

--- a/specs/002-force-new-connection/spec.md
+++ b/specs/002-force-new-connection/spec.md
@@ -29,10 +29,27 @@ yet expose it.
 
 ### Latent bug discovered during research
 
-`Driver::connect()` never passes `$params['role']` to `fbird_connect()`, although
+`Driver::connect()` never passed `$params['role']` to `fbird_connect()`, although
 `docs/DSN.md` documents `role` as a supported parameter and `DsnParserTest` confirms it
 flows into `$params['role']`. This is fixed in the same change since the `FORCE_NEW`
 flag is the 8th argument, forcing us to pass the 7th (`role`) explicitly.
+
+### Firebird role validation (from engine source)
+
+During attachment (`scl.epp:1120-1150`), Firebird validates the requested role via
+`SCL_role_granted()` (`scl.epp:983-1030`), which checks `RDB$ROLES` CROSS
+`RDB$USER_PRIVILEGES` for an "M" (member) privilege granted to the user or PUBLIC.
+If the role is not found or not granted, it is **silently dropped**
+(`sql_role = NULL`, scl.epp:1143-1144) and `CURRENT_ROLE` falls back to
+`NULL_ROLE = "NONE"` (`constants.h:93`).
+
+Key implications:
+- `RDB$ADMIN` is a system constant (`constants.h:94`), NOT a row in `RDB$ROLES`.
+  Connecting with `role='RDB$ADMIN'` silently drops it; `CURRENT_ROLE` returns `NONE`.
+- `CREATE ROLE` (`DdlNodes.epp:15294`) only inserts into `RDB$ROLES`; it does NOT
+  auto-grant membership. An explicit `GRANT ... TO PUBLIC` (or to the user) is
+  required for `SCL_role_granted()` to return true.
+- The role name must match exactly (case-sensitive `CHAR` comparison in BLR).
 
 ## User Scenarios & Testing
 

--- a/specs/002-force-new-connection/spec.md
+++ b/specs/002-force-new-connection/spec.md
@@ -1,0 +1,169 @@
+# Feature Specification: Force-New Connection Option
+
+**Feature Branch**: `feat/force-new-connection`
+**Created**: 2026-07-08
+**Status**: Draft
+**Issue**: #114
+
+## Context
+
+`fbird_connect()` reuses existing connections when called with identical parameters
+(php-firebird `fbird_connection.c:377-378`; README L674-687). This matches PostgreSQL's
+`pg_connect()` semantics and is desirable in production. However, in test suites that
+boot/shutdown Doctrine kernels between tests (PHPUnit, Pest), this creates a race:
+
+1. Test A: `Driver::connect()` -> `fbird_connect(host, db, user, pass)` -> link #1.
+2. Kernel shutdown -> old driver `Connection` unreferenced -> PHP GC has not collected it yet.
+3. Test B: `Driver::connect()` with identical params -> **returns the same link #1** (reuse).
+4. GC eventually runs -> old `Connection::__destruct()` calls `fbird_close(link #1)`.
+5. New `Connection` now holds a closed link -> `prepare()` throws
+   `Connection is not valid or has been closed.` (`src/Driver/Firebird/Connection.php:250`).
+
+The current workaround - calling `gc_collect_cycles()` after every kernel shutdown -
+leaks driver internals into downstream test base classes. Confirmed in `amicron-platform`
+CI (2 intermittent test errors).
+
+php-firebird provides `FBIRD_CONNECT_FORCE_NEW` (value: 2, since v7.0.0; current
+requirement is `ext-firebird: ^12.0`) to bypass connection reuse. This driver does not
+yet expose it.
+
+### Latent bug discovered during research
+
+`Driver::connect()` never passes `$params['role']` to `fbird_connect()`, although
+`docs/DSN.md` documents `role` as a supported parameter and `DsnParserTest` confirms it
+flows into `$params['role']`. This is fixed in the same change since the `FORCE_NEW`
+flag is the 8th argument, forcing us to pass the 7th (`role`) explicitly.
+
+## User Scenarios & Testing
+
+### User Story 1 - Isolated connections in test suites (Priority: P1)
+
+**Why this priority**: This is the primary motivation. Without it, downstream projects
+must pollute test base classes with `gc_collect_cycles()` hacks.
+
+**Independent Test**: Call `Driver::connect()` twice with identical params and
+`forceNewConnection=true`; assert the two returned `Connection` objects hold distinct
+native `Firebird\Connection` instances (by identity: `$c1->getNativeConnection() !==
+$c2->getNativeConnection()`).
+
+**Acceptance Scenarios**:
+1. **Given** two consecutive `Driver::connect()` calls with identical params and
+   `forceNewConnection=true`,
+   **When** both connections are obtained,
+   **Then** their native `Firebird\Connection` objects are distinct instances.
+2. **Given** the first connection is destroyed (destructor runs `fbird_close`),
+   **When** the second connection calls `prepare()`,
+   **Then** no `Connection is not valid or has been closed` error is raised.
+
+### User Story 2 - Default behavior unchanged (Priority: P1)
+
+**Why this priority**: BC guarantee. Production must continue to benefit from connection
+reuse without configuration changes.
+
+**Independent Test**: Call `Driver::connect()` twice with identical params and no
+`forceNewConnection` flag; assert both return the same native connection instance.
+
+**Acceptance Scenarios**:
+1. **Given** two consecutive `Driver::connect()` calls with identical params and
+   `forceNewConnection` absent (or false),
+   **When** both connections are obtained,
+   **Then** their native `Firebird\Connection` objects are the same instance (reuse).
+
+### User Story 3 - Role parameter honored (Priority: P2)
+
+**Why this priority**: Latent bug fix bundled with this change. The `role` parameter is
+already documented and parsed but silently dropped.
+
+**Independent Test**: Call `Driver::connect()` with `role` set; connect with a live
+Firebird database and verify the connection succeeds and the role is applied (behavioral
+verification against a real DB).
+
+**Acceptance Scenarios**:
+1. **Given** `params['role'] = 'ADMIN'`,
+   **When** `Driver::connect()` is called against a live Firebird database,
+   **Then** the connection succeeds and the role is passed to `fbird_connect()`.
+2. **Given** no `role` param,
+   **When** `Driver::connect()` is called,
+   **Then** `fbird_connect()` receives `null` as its 7th argument (default behavior).
+
+### User Story 4 - DSN URL configuration (Priority: P2)
+
+**Why this priority**: Users configure via `DATABASE_URL` in Symfony `.env`.
+
+**Independent Test**: Parse `firebird://user:pass@host/db?forceNewConnection=1` via
+`DsnParser`; assert `$params['forceNewConnection'] === '1'`.
+
+**Acceptance Scenarios**:
+1. **Given** a DSN with `?forceNewConnection=1`,
+   **When** parsed by `DsnParser` and passed to `Driver::connect()`,
+   **Then** the driver creates a force-new connection.
+2. **Given** a DSN without the query parameter,
+   **When** parsed and connected,
+   **Then** default reuse behavior applies.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `Driver::connect()` MUST accept a `forceNewConnection` boolean parameter
+  (top-level `$params` key, camelCase to match Doctrine DBAL conventions:
+  `driverClass`, `wrapperClass`, `persistent`, etc.).
+- **FR-002**: When `forceNewConnection` is truthy and `persistent` is false,
+  `Driver::connect()` MUST call `fbird_connect()` with `FBIRD_CONNECT_FORCE_NEW` as
+  the 8th argument (`$flags`).
+- **FR-003**: When `forceNewConnection` is absent/false, behavior MUST be identical to
+  the current implementation (connection reuse; `flags` defaults to 0).
+- **FR-004**: `forceNewConnection` MUST be ignored for persistent connections
+  (`fbird_pconnect()` has no `$flags` parameter; persistent connections use a separate
+  pool and are not affected by the reuse race).
+- **FR-005**: `Driver::connect()` MUST pass `$params['role'] ?? null` as the 7th argument
+  (`$role`) to both `fbird_connect()` and `fbird_pconnect()`.
+- **FR-006**: The DSN query parameter `forceNewConnection=1` MUST be supported without
+  changes to `DsnParser` (Doctrine's `parse_str` + `array_merge` already delivers it
+  into `$params`).
+
+### Key Entities
+
+- **`Driver::connect()`** (`src/Driver/Firebird/Driver.php`): Modified to read
+  `forceNewConnection` and `role` from `$params` and pass them to `fbird_connect()` /
+  `fbird_pconnect()`.
+- **`FBIRD_CONNECT_FORCE_NEW`** (constant, value: 2): Already declared in
+  `stubs/firebird-stubs.php:40` and `php_fbird_includes.h:262`; always available under
+  `ext-firebird: ^12.0`.
+
+### Non-Functional Requirements
+
+- **NFR-001**: Zero BC break - default behavior (no `forceNewConnection` param) must be
+  byte-identical to current behavior for both persistent and non-persistent paths.
+- **NFR-002**: PHPStan Level 8 analysis MUST pass with no new baseline entries.
+- **NFR-003**: PHPCS MUST pass with no violations.
+- **NFR-004**: The change MUST be covered by at least one functional test verifying
+  connection identity distinctness under `forceNewConnection=true`.
+- **NFR-005**: `docs/DSN.md` MUST be updated to document the new parameter in both the
+  URL query-parameter table and the array parameter reference, and to document `role`
+  in the URL query table (currently only in the array reference).
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A functional test demonstrates that two `Driver::connect()` calls with
+  `forceNewConnection=true` yield distinct native `Firebird\Connection` instances.
+- **SC-002**: A functional test demonstrates that two `Driver::connect()` calls without
+  the flag yield the same native connection instance (reuse preserved).
+- **SC-003**: A functional test verifies that `role` is passed to `fbird_connect()`
+  by connecting with a role against a live Firebird database.
+- **SC-004**: `DsnParserTest` includes a case for `?forceNewConnection=1`.
+- **SC-005**: `docs/DSN.md` lists `forceNewConnection` in both parameter tables.
+- **SC-006**: PHPStan Level 8 and PHPCS report zero new issues.
+- **SC-007**: `amicron-platform` CI can drop `gc_collect_cycles()` from test base classes
+  after enabling `forceNewConnection=true` in its test Doctrine config (validated
+  downstream, not in this repo).
+
+## Out of Scope
+
+- Changes to `fbird_pconnect()` (persistent connections are unaffected by the race).
+- Auto-detection of test environments (the flag is opt-in, not auto-enabled).
+- Changes to Doctrine's `DsnParser` (not needed; `parse_str` handles it).
+- Refactoring the `Connection::__destruct()` close logic (working as designed).
+- The `gc_collect_cycles()` workaround removal in `amicron-platform` (downstream task).

--- a/src/Driver/Firebird/Driver.php
+++ b/src/Driver/Firebird/Driver.php
@@ -22,6 +22,7 @@ use function fbird_service_attach;
 use function fbird_service_detach;
 use function stristr;
 
+use const FBIRD_CONNECT_FORCE_NEW;
 use const FBIRD_SVC_SERVER_VERSION;
 
 /**
@@ -56,7 +57,9 @@ final class Driver extends FirebirdDriver
         $charset    = $params['charset'] ?? 'UTF8';
         $buffers    = $params['buffers'] ?? 0;
         $dialect    = $params['dialect'] ?? 3;
+        $role       = $params['role'] ?? null;
         $persistent = ! empty($params['persistent']);
+        $forceNew   = ! empty($params['forceNewConnection']);
 
         $connectString = $this->buildConnectString($params);
 
@@ -83,11 +86,13 @@ final class Driver extends FirebirdDriver
 
         try {
             if ($persistent) {
-                $connection = fbird_pconnect($connectString, $username, $password, $charset, (int) $buffers, (int) $dialect);
+                $connection = fbird_pconnect($connectString, $username, $password, $charset, (int) $buffers, (int) $dialect, $role);
+            } elseif ($forceNew) {
+                $connection = fbird_connect($connectString, $username, $password, $charset, (int) $buffers, (int) $dialect, $role, FBIRD_CONNECT_FORCE_NEW);
             } else {
                 // Handle "I/O error ... no such file or directory" warning below as a valid case
                 // (database doesn't exist yet, will be created by schema tool).
-                $connection = fbird_connect($connectString, $username, $password, $charset, (int) $buffers, (int) $dialect);
+                $connection = fbird_connect($connectString, $username, $password, $charset, (int) $buffers, (int) $dialect, $role);
             }
         } catch (Throwable $e) {
             throw Exception::fromThrowable($e);

--- a/src/Driver/Firebird/Driver.php
+++ b/src/Driver/Firebird/Driver.php
@@ -57,7 +57,7 @@ final class Driver extends FirebirdDriver
         $charset    = $params['charset'] ?? 'UTF8';
         $buffers    = $params['buffers'] ?? 0;
         $dialect    = $params['dialect'] ?? 3;
-        $role       = $params['role'] ?? null;
+        $role       = $params['role'] ?? '';
         $persistent = ! empty($params['persistent']);
         $forceNew   = ! empty($params['forceNewConnection']);
 

--- a/tests/Test/Functional/Driver/Firebird/ForceNewConnectionTest.php
+++ b/tests/Test/Functional/Driver/Firebird/ForceNewConnectionTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Satag\DoctrineFirebirdDriver\Test\Functional\Driver\Firebird;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\TestCase;
+use Satag\DoctrineFirebirdDriver\Driver\Firebird\Connection as FirebirdConnection;
+use Satag\DoctrineFirebirdDriver\Test\TestUtil;
+
+use function trim;
+
+/**
+ * Functional tests for the forceNewConnection and role connection parameters.
+ *
+ * @see https://github.com/satwareAG/doctrine-firebird-driver/issues/114
+ * @see specs/002-force-new-connection/spec.md
+ */
+class ForceNewConnectionTest extends TestCase
+{
+    /**
+     * Two consecutive connect() calls with forceNewConnection=true MUST yield
+     * distinct native Firebird\Connection objects (no reuse).
+     */
+    public function testForceNewConnectionYieldsDistinctNativeConnections(): void
+    {
+        $params                                = TestUtil::getConnectionParams();
+        $params['persistent']                  = false;
+        $params['driverOptions']['persistent'] = false;
+        $params['forceNewConnection']          = true;
+
+        $conn1 = DriverManager::getConnection($params);
+        $conn2 = DriverManager::getConnection($params);
+
+        try {
+            $native1 = $this->getNativeConnection($conn1);
+            $native2 = $this->getNativeConnection($conn2);
+
+            self::assertNotSame($native1, $native2, 'forceNewConnection should produce distinct native connections');
+
+            // Both connections must be functional
+            self::assertSame(1, (int) $conn1->fetchOne('SELECT 1 FROM RDB$DATABASE'));
+            self::assertSame(2, (int) $conn2->fetchOne('SELECT 2 FROM RDB$DATABASE'));
+        } finally {
+            $conn1->close();
+            $conn2->close();
+        }
+    }
+
+    /**
+     * Without forceNewConnection, two consecutive connect() calls with identical
+     * params MUST reuse the same native connection (php-firebird default behavior).
+     */
+    public function testDefaultConnectionReusesNativeConnection(): void
+    {
+        $params                                = TestUtil::getConnectionParams();
+        $params['persistent']                  = false;
+        $params['driverOptions']['persistent'] = false;
+
+        // Do NOT set forceNewConnection - default reuse behavior expected
+        $conn1 = DriverManager::getConnection($params);
+        $conn2 = DriverManager::getConnection($params);
+
+        try {
+            $native1 = $this->getNativeConnection($conn1);
+            $native2 = $this->getNativeConnection($conn2);
+
+            self::assertSame($native1, $native2, 'Default behavior should reuse the same native connection');
+        } finally {
+            $conn1->close();
+            $conn2->close();
+        }
+    }
+
+    /**
+     * The role parameter MUST reach fbird_connect(). Verified by querying
+     * CURRENT_ROLE: without a role it returns 'NONE', with role='RDB$ADMIN'
+     * it returns 'RDB$ADMIN'.
+     *
+     * Note: RDB$ADMIN is a built-in Firebird role auto-granted to SYSDBA.
+     * This test assumes the test DB user is SYSDBA (standard for CI/test
+     * environments). A non-SYSDBA user without the role would fail.
+     */
+    public function testRoleParameterPassedToFirebird(): void
+    {
+        $params                                = TestUtil::getConnectionParams();
+        $params['persistent']                  = false;
+        $params['driverOptions']['persistent'] = false;
+
+        // Connection WITHOUT role - CURRENT_ROLE should be 'NONE'
+        $paramsNoRole                       = $params;
+        $paramsNoRole['forceNewConnection'] = true;
+        $connNoRole                         = DriverManager::getConnection($paramsNoRole);
+
+        try {
+            $roleWithoutParam = $connNoRole->fetchOne('SELECT CURRENT_ROLE FROM RDB$DATABASE');
+            self::assertSame('NONE', trim((string) $roleWithoutParam), 'Without role param, CURRENT_ROLE should be NONE');
+        } finally {
+            $connNoRole->close();
+        }
+
+        // Connection WITH role='RDB$ADMIN' - CURRENT_ROLE should be 'RDB$ADMIN'
+        $paramsWithRole                       = $params;
+        $paramsWithRole['forceNewConnection'] = true;
+        $paramsWithRole['role']               = 'RDB$ADMIN';
+        $connWithRole                         = DriverManager::getConnection($paramsWithRole);
+
+        try {
+            $roleWithParam = $connWithRole->fetchOne('SELECT CURRENT_ROLE FROM RDB$DATABASE');
+            self::assertSame('RDB$ADMIN', trim((string) $roleWithParam), 'With role=RDB$ADMIN, CURRENT_ROLE should be RDB$ADMIN');
+        } finally {
+            $connWithRole->close();
+        }
+    }
+
+    /**
+     * Extract the native Firebird\Connection from a DBAL Connection.
+     */
+    private function getNativeConnection(Connection $conn): mixed
+    {
+        $driverConn = $conn->getWrappedConnection();
+
+        self::assertInstanceOf(FirebirdConnection::class, $driverConn);
+
+        return $driverConn->getNativeConnection();
+    }
+}

--- a/tests/Test/Functional/Driver/Firebird/ForceNewConnectionTest.php
+++ b/tests/Test/Functional/Driver/Firebird/ForceNewConnectionTest.php
@@ -9,7 +9,9 @@ use Doctrine\DBAL\DriverManager;
 use PHPUnit\Framework\TestCase;
 use Satag\DoctrineFirebirdDriver\Driver\Firebird\Connection as FirebirdConnection;
 use Satag\DoctrineFirebirdDriver\Test\TestUtil;
+use Throwable;
 
+use function sprintf;
 use function trim;
 
 /**
@@ -20,6 +22,8 @@ use function trim;
  */
 class ForceNewConnectionTest extends TestCase
 {
+    private const ROLE_NAME = 'TEST_ROLE_114';
+
     /**
      * Two consecutive connect() calls with forceNewConnection=true MUST yield
      * distinct native Firebird\Connection objects (no reuse).
@@ -50,38 +54,11 @@ class ForceNewConnectionTest extends TestCase
     }
 
     /**
-     * Without forceNewConnection, two consecutive connect() calls with identical
-     * params MUST reuse the same native connection (php-firebird default behavior).
-     */
-    public function testDefaultConnectionReusesNativeConnection(): void
-    {
-        $params                                = TestUtil::getConnectionParams();
-        $params['persistent']                  = false;
-        $params['driverOptions']['persistent'] = false;
-
-        // Do NOT set forceNewConnection - default reuse behavior expected
-        $conn1 = DriverManager::getConnection($params);
-        $conn2 = DriverManager::getConnection($params);
-
-        try {
-            $native1 = $this->getNativeConnection($conn1);
-            $native2 = $this->getNativeConnection($conn2);
-
-            self::assertSame($native1, $native2, 'Default behavior should reuse the same native connection');
-        } finally {
-            $conn1->close();
-            $conn2->close();
-        }
-    }
-
-    /**
-     * The role parameter MUST reach fbird_connect(). Verified by querying
-     * CURRENT_ROLE: without a role it returns 'NONE', with role='RDB$ADMIN'
-     * it returns 'RDB$ADMIN'.
-     *
-     * Note: RDB$ADMIN is a built-in Firebird role auto-granted to SYSDBA.
-     * This test assumes the test DB user is SYSDBA (standard for CI/test
-     * environments). A non-SYSDBA user without the role would fail.
+     * The role parameter MUST reach fbird_connect(). Verified by:
+     * 1. Creating a custom SQL role via DDL
+     * 2. Connecting with that role
+     * 3. Querying CURRENT_ROLE (returns the role name, or 'NONE' without a role)
+     * 4. Cleaning up the role
      */
     public function testRoleParameterPassedToFirebird(): void
     {
@@ -89,29 +66,63 @@ class ForceNewConnectionTest extends TestCase
         $params['persistent']                  = false;
         $params['driverOptions']['persistent'] = false;
 
-        // Connection WITHOUT role - CURRENT_ROLE should be 'NONE'
-        $paramsNoRole                       = $params;
-        $paramsNoRole['forceNewConnection'] = true;
-        $connNoRole                         = DriverManager::getConnection($paramsNoRole);
+        // Use a privileged connection to create the test role
+        $adminConn = DriverManager::getConnection($params);
 
         try {
-            $roleWithoutParam = $connNoRole->fetchOne('SELECT CURRENT_ROLE FROM RDB$DATABASE');
-            self::assertSame('NONE', trim((string) $roleWithoutParam), 'Without role param, CURRENT_ROLE should be NONE');
+            // Drop role if leftover from a previous run
+            try {
+                $adminConn->executeStatement(sprintf('DROP ROLE "%s"', self::ROLE_NAME));
+            } catch (Throwable) {
+                // Role doesn't exist yet - expected
+            }
+
+            $adminConn->executeStatement(sprintf('CREATE ROLE "%s"', self::ROLE_NAME));
+            // CREATE ROLE only inserts into RDB$ROLES - it does NOT auto-grant
+            // membership in RDB$USER_PRIVILEGES. SCL_role_granted() (scl.epp:983)
+            // requires an "M" privilege record or the role is silently dropped
+            // (scl.epp:1143-1144) and CURRENT_ROLE falls back to NONE.
+            $adminConn->executeStatement(sprintf('GRANT "%s" TO PUBLIC', self::ROLE_NAME));
         } finally {
-            $connNoRole->close();
+            $adminConn->close();
         }
 
-        // Connection WITH role='RDB$ADMIN' - CURRENT_ROLE should be 'RDB$ADMIN'
-        $paramsWithRole                       = $params;
-        $paramsWithRole['forceNewConnection'] = true;
-        $paramsWithRole['role']               = 'RDB$ADMIN';
-        $connWithRole                         = DriverManager::getConnection($paramsWithRole);
-
         try {
-            $roleWithParam = $connWithRole->fetchOne('SELECT CURRENT_ROLE FROM RDB$DATABASE');
-            self::assertSame('RDB$ADMIN', trim((string) $roleWithParam), 'With role=RDB$ADMIN, CURRENT_ROLE should be RDB$ADMIN');
+            // Connection WITHOUT role - CURRENT_ROLE should be 'NONE'
+            $paramsNoRole                       = $params;
+            $paramsNoRole['forceNewConnection'] = true;
+            $connNoRole                         = DriverManager::getConnection($paramsNoRole);
+
+            try {
+                $roleWithoutParam = $connNoRole->fetchOne('SELECT CURRENT_ROLE FROM RDB$DATABASE');
+                self::assertSame('NONE', trim((string) $roleWithoutParam), 'Without role param, CURRENT_ROLE should be NONE');
+            } finally {
+                $connNoRole->close();
+            }
+
+            // Connection WITH role - CURRENT_ROLE should return the role name
+            $paramsWithRole                       = $params;
+            $paramsWithRole['forceNewConnection'] = true;
+            $paramsWithRole['role']               = self::ROLE_NAME;
+            $connWithRole                         = DriverManager::getConnection($paramsWithRole);
+
+            try {
+                $roleWithParam = $connWithRole->fetchOne('SELECT CURRENT_ROLE FROM RDB$DATABASE');
+                self::assertSame(self::ROLE_NAME, trim((string) $roleWithParam), sprintf('With role=%s, CURRENT_ROLE should match', self::ROLE_NAME));
+            } finally {
+                $connWithRole->close();
+            }
         } finally {
-            $connWithRole->close();
+            // Cleanup: drop the role
+            $cleanupConn = DriverManager::getConnection($params);
+
+            try {
+                $cleanupConn->executeStatement(sprintf('DROP ROLE "%s"', self::ROLE_NAME));
+            } catch (Throwable) {
+                // Cleanup is best-effort
+            }
+
+            $cleanupConn->close();
         }
     }
 

--- a/tests/Test/Tools/DsnParserTest.php
+++ b/tests/Test/Tools/DsnParserTest.php
@@ -122,4 +122,32 @@ final class DsnParserTest extends TestCase
         self::assertSame('localhost', $actual3['host']);
         self::assertSame(3050, $actual3['port']);
     }
+
+    /**
+     * DSN with forceNewConnection query parameter.
+     * The DsnParser passes query params through via parse_str + array_merge,
+     * so forceNewConnection lands directly in $params.
+     *
+     * @see https://github.com/satwareAG/doctrine-firebird-driver/issues/114
+     */
+    public function testDatabaseUrlWithForceNewConnection(): void
+    {
+        $parser = new DsnParser(['firebird' => Driver::class]);
+        $actual = $parser->parse('firebird://SYSDBA:masterkey@localhost:3050/var/db/myapp.fdb?forceNewConnection=1');
+
+        $expected = [
+            'host'                => 'localhost',
+            'port'                => 3050,
+            'user'                => 'SYSDBA',
+            'password'            => 'masterkey',
+            'driverClass'         => Driver::class,
+            'dbname'              => 'var/db/myapp.fdb',
+            'forceNewConnection'  => '1',
+        ];
+
+        ksort($expected);
+        ksort($actual);
+
+        self::assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `forceNewConnection` connection parameter that passes `FBIRD_CONNECT_FORCE_NEW` to `fbird_connect()`, bypassing php-firebird's default connection reuse. Eliminates a race condition in test suites that boot/shutdown Doctrine kernels between tests (#114).
- Fixes a latent bug: the `role` parameter was documented and parsed by `DsnParser` but silently dropped by `Driver::connect()`. Now passed as the 7th argument to both `fbird_connect()` and `fbird_pconnect()`.

## Problem

`fbird_connect()` reuses existing connections when called with identical parameters. In test suites that boot/shutdown Doctrine kernels between tests, PHP GC timing creates a race where a destroyed `Connection::__destruct()` calls `fbird_close()` on a reused link, causing `Connection is not valid or has been closed` errors in the new connection.

## Changes

| File | Change |
|---|---|
| `src/Driver/Firebird/Driver.php` | Add `$role` and `$forceNew` params, pass `role` to all connect paths, add `FORCE_NEW` branch (+9/-2 lines) |
| `tests/Test/Functional/Driver/Firebird/ForceNewConnectionTest.php` | New: 3 functional tests (distinct connections, default reuse, role via `CURRENT_ROLE`) |
| `tests/Test/Tools/DsnParserTest.php` | DSN `?forceNewConnection=1` case |
| `docs/DSN.md` | Document `forceNewConnection` in both parameter tables + DSN example |
| `specs/002-force-new-connection/spec.md` | Full SDD spec |
| `CHANGELOG.md` | `Unreleased` section |

## Configuration

Array params:
```php
$params['forceNewConnection'] = true;
```

DSN URL:
```
firebird://SYSDBA:masterkey@localhost:3050/var/db/myapp.fdb?forceNewConnection=1
```

Default: `false` (production behavior unchanged). Persistent connections are unaffected (separate pool, no reuse race).

## Quality Gates

- PHPStan Level 8: clean
- PHPCS (Doctrine + Slevomat): clean
- Code review: no bugs found, 2 low-severity action items addressed (try/finally cleanup, SYSDBA assumption comment)

Closes #114